### PR TITLE
github-monday: update variable selectors

### DIFF
--- a/github-monday/github-monday.user.css
+++ b/github-monday/github-monday.user.css
@@ -2,7 +2,7 @@
 @name         github-monday
 @author       Karl_255
 @namespace    github.com/Karl255
-@version      1.0.3
+@version      1.0.4
 @description  A style to fix the calendar's first day of week on GitHub user profile pages.
 @homepageURL  https://github.com/Karl255/UserCSS-Styles
 @supportURL   https://github.com/Karl255/UserCSS-Styles/issues

--- a/github-monday/github-monday.user.css
+++ b/github-monday/github-monday.user.css
@@ -13,12 +13,12 @@
 
 @-moz-document domain("github.com") {
 	/* when the activity overview is enabled the grid rects are 10px * 10px (3px spacing) */
-	.mt-4.position-relative > .d-flex .ContributionCalendar-grid {
+	.ContributionCalendar-grid[style*="border-spacing: 3px"] {
 		--dist: 13px;
 	}
 
-	/* but when it's disabled, they're 12px * 12px (3px spacing) */
-	.mt-4.position-relative > .js-yearly-contributions .ContributionCalendar-grid {
+	/* but when it's disabled, they're 11px * 11px (4px spacing) */
+	.ContributionCalendar-grid[style*="border-spacing: 4px"] {
 		--dist: 15px;
 	}
 


### PR DESCRIPTION
The current selectors have stopped working and the `--dist` variable remained unset. I have examined the attributes in the parent nodes of the table, but couldn't find any other way to determine whether activity overview is active or not, apart from checking the inline style of the table itself. Also updated description for the updated border-spacing.